### PR TITLE
Fix script working directory, add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Archive
+archive

--- a/backup-docker-volumes.sh
+++ b/backup-docker-volumes.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Create a directory for the backups if it doesn't exist
-mkdir -p ${PWD}/archive
+backup_dir="$(dirname "$0")/archive"
+# PWD will give the user's execution directory, not this repository
+mkdir "$backup_dir"
+# -p is unnecessary
 
 # Get the list of docker volumes
 volumes=$(docker volume ls -q)
@@ -11,5 +14,5 @@ for source_volume in $volumes; do
   backup_date=$(date +"%Y%m%d_%H%M%S")
   backup_file="${source_volume}_${backup_date}.tar.gz"
   echo "Creating backup for volume: ${source_volume}, backup file: ${backup_file}"
-  docker run --tty --rm --interactive --volume ${source_volume}:/source --volume ${PWD}/archive:/backup alpine tar czvf /backup/${backup_file} -C /source .
+  docker run --tty --rm --interactive --volume ${source_volume}:/source --volume ${backup_dir}:/backup alpine tar czvf /backup/${backup_file} -C /source .
 done

--- a/restore-docker-volumes.sh
+++ b/restore-docker-volumes.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Directory containing the backup files
-backup_dir="${PWD}/archive"
+backup_dir="$(dirname "$0")/archive"
+# PWD would give the working directory
+# If the user did `backup-restore-docker-volumes/restore-docker-bolumes.sh`
+    # the script would search for archive within the directory containing this repo
 
 # Check if the backup directory exists
 if [ ! -d "$backup_dir" ]; then


### PR DESCRIPTION
# Modifications
## Backup Script
- Assigned archive path to `$backup_dir` similarly to the Restore script
- `${PWD}` will return the user's working directory, not the script's location, use `$(dirname "$0")` for that
- `-p` Unnecessary in the `mkdir`, seeing as the directory containing the script exists

## Restore Script
Changed `${PWD}` to `$(dirname "$0")` same as backup script

# Additions
`.gitignore` - For the archive not to be committed into the repository