### PR TITLE
Script formatting

### DIFF
--- a/backup-docker-volumes.sh
+++ b/backup-docker-volumes.sh
@@ -12,7 +12,11 @@ volumes=$(docker volume ls -q)
 # Loop through each volume and create a backup
 for source_volume in $volumes; do
   backup_date=$(date +"%Y%m%d_%H%M%S")
-  backup_file="${source_volume}_${backup_date}.tar.gz"
-  echo "Creating backup for volume: ${source_volume}, backup file: ${backup_file}"
-  docker run --tty --rm --interactive --volume ${source_volume}:/source --volume ${backup_dir}:/backup alpine tar czvf /backup/${backup_file} -C /source .
+  backup_file="${source_volume}_$backup_date.tar.gz"
+  echo Creating backup for volume: $source_volume, backup file: $backup_file
+
+  docker run --rm -it \
+  -v $source_volume:/source -v $backup_dir:/backup \
+  alpine \
+  tar czvf /backup/$backup_file -C /source .
 done

--- a/restore-docker-volumes.sh
+++ b/restore-docker-volumes.sh
@@ -8,7 +8,7 @@ backup_dir="$(dirname "$0")/archive"
 
 # Check if the backup directory exists
 if [ ! -d "$backup_dir" ]; then
-  echo "Backup directory not found: $backup_dir"
+  echo Backup directory not found: $backup_dir
   exit 1
 fi
 
@@ -16,18 +16,21 @@ fi
 for backup_file in "$backup_dir"/*.tar.gz; do
   # Extract the volume name from the backup file name
   base_name=$(basename "$backup_file")
-  volume_name=$(echo "$base_name" | sed -E 's/(.+)_[0-9]{8}_[0-9]{6}\.tar\.gz/\1/')
+  volume_name=$(echo $base_name | sed -E 's/(.+)_[0-9]{8}_[0-9]{6}\.tar\.gz/\1/')
   
   # Check if the volume already exists
   if docker volume ls -q | grep -q "^${volume_name}$"; then
-    echo "Volume ${volume_name} already exists. Skipping..."
+    echo Volume $volume_name already exists. Skipping...
   else
-    echo "Restoring backup for volume: ${volume_name}, backup file: ${backup_file}"
+    echo Restoring backup for volume: $volume_name, backup file: $backup_file
 
     # Create a new volume with the extracted volume name
     docker volume create "${volume_name}"
 
     # Restore the backup to the new volume
-    docker run --rm --interactive --tty --volume ${volume_name}:/restore --volume ${backup_dir}:/backup alpine tar xzvf /backup/"${base_name}" -C /restore
+    docker run --rm -it \
+    -v ${volume_name}:/restore -v ${backup_dir}:/backup \
+    alpine \
+    tar xzvf /backup/"${base_name}" -C /restore
   fi
 done


### PR DESCRIPTION
- Removed unnecessary `${var}` in favor of `$var`
- Removed unnecessary quotation marks
- Shortened command options to GNU standard (ex. `--interactive --tty` -> `-it`)
- Split `docker run` command into lines for readability

I will probably be using these scripts for my [docker-volman](https://github.com/DeanAyalon/docker-volman) repo, would you like for credit to be attributed to you?