### PR TITLE
Fix: Multiple backups; Docker daemon down

### DIFF
--- a/backup-docker-volumes.sh
+++ b/backup-docker-volumes.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 
+# Execution context
+cd "$(dirname "$0")"
 # Create a directory for the backups if it doesn't exist
-backup_dir="$(dirname "$0")/archive"
-# PWD will give the user's execution directory, not this repository
-mkdir "$backup_dir"
-# -p is unnecessary
+[ ! -d archive ] && mkdir archive
+cd archive
 
 # Get the list of docker volumes
-volumes=$(docker volume ls -q)
+volumes=$(docker volume ls -q) || exit 1
 
 # Loop through each volume and create a backup
-for source_volume in $volumes; do
-  backup_date=$(date +"%Y%m%d_%H%M%S")
-  backup_file="${source_volume}_$backup_date.tar.gz"
-  echo Creating backup for volume: $source_volume, backup file: $backup_file
+for volume in $volumes; do
+    backup_date=$(date +"%Y%m%d_%H%M%S")
+    backup_file="${volume}_$backup_date.tar.gz"
+    echo Creating backup for volume: $volume, backup file: $backup_file
 
-  docker run --rm -it \
-  -v $source_volume:/source -v $backup_dir:/backup \
-  alpine \
-  tar czvf /backup/$backup_file -C /source .
+    volume_dir=./$volume
+    [ ! -d "$volume_dir" ] && mkdir -p "$volume_dir"
+
+    docker run --rm -it \
+    -v $volume:/source -v $volume_dir:/backup \
+    alpine \
+    tar czvf /backup/$backup_file -C /source .
 done


### PR DESCRIPTION
Fix: Having multiple backup files only restores oldest backup - Now restores the latest backup for each 
volume
Fix: Scripts trying to run when Docker daemon is down

Each volume now has its own directory in the archive

Optimizations:
- Execution context instead of getting full path
- Restore: Save volume list into memory instead of calling `docker volume ls -q` every iteration of the for loop
- Simpler variable names
